### PR TITLE
Remove unit tests from precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,6 @@ repos:
       - id: darglint
   - repo: local
     hooks:
-      - id: pytest
-        name: pytest
-        entry: pytest
-        language: system
-        pass_filenames: false
-        always_run: true
-  - repo: local
-    hooks:
       - id: covbadge
         name: Coverage badge update
         entry: coverage-badge -o .github/badges/coverage.svg -f

--- a/README.md
+++ b/README.md
@@ -124,7 +124,31 @@ pre-commit install
 
 ---
 
-Then you can just try to commit your code. If anything fails (linters, tests, etc...), your code will not be committed. You can just fix your code and try to commit again !
+Then you can just try to commit your code. If you code does not meet the quality required by linters, it will not be committed. You can just fix your code and try to commit again !
+
+---
+
+You can manually run the pre-commit hooks with :
+
+```bash
+pre-commit run --all-files
+```
+
+### Tests
+
+When you contribute, you need to make sure all the unit-tests pass. You should also add tests if necessary !
+
+You can run the tests with :
+
+```bash
+pytest
+```
+
+---
+
+Tests are not included in the pre-commit hooks, because running the tests might be slow, and for the sake of developpers we want the pre-commit hooks to be fast !
+
+Pre-commit hooks will not run the tests, but it will automatically update the coverage badge !
 
 ### Documentation
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -96,7 +96,7 @@ Unit-tests are implemented with [`pytest`](https://docs.pytest.org/).
 You can run the unit-tests manually by running :
 
 ```bash
-python -m pytest
+pytest
 ```
 
 !!! note "Where to modify it ?"
@@ -113,6 +113,11 @@ By default, the tests will fail if the test coverage is below **80%**.
 !!! note "Where to modify it ?"
     You can change the `pytest` configuration in `pyproject.toml`. You can also change the coverage threshold in the same file.
 
+!!! info
+    After running the unit-tests, you can update the coverage badge manually with `coverage-badge -o .github/badges/coverage.svg -f`.
+
+    Note that you don't need to do it by yourself, a pre-commit hook will take care of that (see [Pre-commit hooks](#pre-commit-hooks)).
+
 ## Pre-commit hooks
 
 Several pre-commit hooks are used in this template repository :
@@ -125,7 +130,6 @@ Several pre-commit hooks are used in this template repository :
 * Lint code with `black`
 * Lint code with `flake518`
 * Lint code with `darglint`
-* Ensure unit-tests pass
 * Ensure the coverage badge is up-to-date
 
 !!! note "Where to modify it ?"

--- a/docs/features.md
+++ b/docs/features.md
@@ -104,6 +104,15 @@ python -m pytest
 
     If you wish to **not** run unit-tests, you need to remove it from the [pre-commit hooks](#pre-commit-hooks) **and** from the [Github actions](#continuous-integration).
 
+---
+
+The tests also check the test coverage, with the `pytest-cov` plugin.
+
+By default, the tests will fail if the test coverage is below **80%**.
+
+!!! note "Where to modify it ?"
+    You can change the `pytest` configuration in `pyproject.toml`. You can also change the coverage threshold in the same file.
+
 ## Pre-commit hooks
 
 Several pre-commit hooks are used in this template repository :

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,13 +85,35 @@ To contribute, install the package locally (see [Installation](#local)), create 
 
 Pre-commit hooks are set to check the code added whenever you commit something.
 
-When you try to commit your code, hooks are run, and if anything fails (_linters, tests, etc..._), your code will not be committed. You then have to fix your code and try to commit again !
+When you try to commit your code, hooks are automatically run, and if you code does not meet the quality required by linters, it will not be committed. You then have to fix your code and try to commit again !
 
-!!! info
+!!! important
     If you never ran the hooks before, install it with :
     ```bash
     pre-commit install
     ```
+
+!!! info
+    You can manually run the pre-commit hooks with :
+    ```bash
+    pre-commit run --all-files
+    ```
+
+### Unit-tests
+
+When you contribute, you need to make sure all the unit-tests pass. You should also add tests if necessary !
+
+You can run the tests with :
+
+```bash
+pytest
+```
+
+!!! info
+    Tests are not included in the pre-commit hooks, because running the tests might be slow, and for the sake of developpers we want the pre-commit hooks to be fast !
+
+!!! hint
+    Pre-commit hooks will not run the tests, but it will automatically update the coverage badge !
 
 ### Documentation
 


### PR DESCRIPTION
<!--- The title of your PR should be short, focused, and to the point. Usually, the title is a complete sentence written as it was an order (imperative sentence) --->

## 🔍️ Description

<!--- Longer description, providing details that the title couldn't provide. Feel free to use images --->
This PR removes `pytest` from pre-commit hooks. Also update docs.

## 🧐 Context

<!--- Provide additional context, like why this PR is needed (what was wrong with previous code) --->
See [this comment](https://github.com/pre-commit/pre-commit-hooks/issues/291#issuecomment-394167917). Basically we don't want to run unit tests in pre-commits, because tests might be slow, but for the sake of developpers, we want fast hooks.

## ⚠️ Side-effects / Shortcomings

<!--- Any side-effects or shortcomings reviewers should be aware of ? --->
None

## ✅ How this was tested ?

<!--- Describe the tests you ran to verify your changes. It's also the place to provide instructions for reproducing the tests / relevant details of the test configuration. --->
Docs building locally.

## 🌱 Checklist

<!--- Add here any task left to do before the PR is ready for review / merging --->
- [x] Perform self-review of my own code
- [ ] Comment the code, particularly in hard-to-understand areas
- [x] Update the documentation accordingly to the new code
- [ ] Lint / format the code
- [ ] Update existing tests / Add new tests
- [ ] Tests are passing locally
