### PR TITLE
Add packages to install for mike

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -19,14 +19,8 @@ Check out [Material for Mkdocs documentation](https://squidfunk.github.io/mkdocs
 
 The documentation is **versioned** and **published as a Github page** with [mike](https://github.com/jimporter/mike).
 
-Check [mike's documentation](https://github.com/jimporter/mike) for more details on how to use it. For a very short summary :
-
-* **`mike deploy --push --update-aliases X.Y`** to push the current documentation version as `X.Y` version.
-* **`mike deploy --push --update-aliases X.Y name`** to push the current documentation version as `X.Y` version, and add an alias `name`.
-* **`mike retitle --push X.Y "title"`** to set the title of `X.Y` as `title`. For example, `title` can be the full version `X.Y.Z`.
-* **`mike set-default --push name`** to set the alias `name` as default.
-* **`mike delete --all --push`** to remove everything (careful with that !).
-* **`mike serve`** to serve the documentation locally (for debugging).
+You can use **`mike serve`** to serve the documentation locally for preview.
+For details on its usage see [usage.md](usage.md).
 
 
 ## Code formatting & linters

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,6 +85,27 @@ Go to the settings of your repository, then in the tab `Actions`, find the secti
 This is needed because the `mike` Github actions needs to push to the `gh-pages` branch to publish your documentation.
 
 
+## Development of the documentation (locally)
+Install these Python packages for mike to work in this configuration:
+```
+$ pip install mike pymdown-extensions mkdocs-material mkdocstrings mkdocstrings-python
+```
+
+Then, run these commands with the version number and name you want to use:
+* **`mike deploy --push --update-aliases X.Y.Z name`
+  - Push the documentation version as `X.Y.Z` version, and add an alias `name`.
+* **`mike retitle --push X.Y "title"`**
+  - Set the title of `X.Y.Z` as `title`.
+    For example, `title` can be the full version `X.Y.Z`.
+* **`mike set-default --push name`** to set the alias `name` as default.
+* **`mike serve`** to serve the documentation locally (for debugging).
+
+* **`mike delete --all --push`** to remove everything!
+     - Cleanup after a quick experiment, but be careful!
+
+Check [mike's documentation](https://github.com/jimporter/mike) for more details on how to use it.
+
+
 ## Add your PyPi API token
 
 The Github action that automatically publish your package to PyPi (see [Features](features.md#continuous-deployment)) requires your [PyPi API token](https://pypi.org/help/#apitoken).


### PR DESCRIPTION
In the current setyo mike needs a number of addional modules. 

Add the pip line and move the detailsed instructions from the general feature page to the usage page.